### PR TITLE
Add home icon and account edit flow

### DIFF
--- a/app/src/main/java/com/andydel/financemanager/data/repository/FinanceRepository.kt
+++ b/app/src/main/java/com/andydel/financemanager/data/repository/FinanceRepository.kt
@@ -20,8 +20,8 @@ import com.andydel.financemanager.domain.model.TransactionType
 import com.andydel.financemanager.domain.model.UserProfile
 import java.time.Instant
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 
 class FinanceRepository(
@@ -104,6 +104,28 @@ class FinanceRepository(
             userId = userId
         )
         return accountDao.insert(entity)
+    }
+
+    suspend fun updateAccount(
+        accountId: Long,
+        name: String,
+        type: AccountType,
+        currencyId: Long,
+        initialBalance: Double
+    ) {
+        val existing = accountDao.getById(accountId) ?: return
+        val updated = existing.copy(
+            name = name,
+            type = type.name,
+            currencyId = currencyId,
+            initialBalance = initialBalance
+        )
+        accountDao.insert(updated)
+    }
+
+    suspend fun getAccount(accountId: Long): Account? {
+        val accounts = observeAccounts().first()
+        return accounts.firstOrNull { it.id == accountId }
     }
 
     suspend fun addTransaction(

--- a/app/src/main/java/com/andydel/financemanager/ui/addaccount/AddAccountScreen.kt
+++ b/app/src/main/java/com/andydel/financemanager/ui/addaccount/AddAccountScreen.kt
@@ -1,6 +1,7 @@
 package com.andydel.financemanager.ui.addaccount
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -42,13 +44,32 @@ fun AddAccountScreen(
     onSave: () -> Unit,
     onClose: () -> Unit
 ) {
+    if (state.isLoading) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            contentAlignment = androidx.compose.ui.Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+        return
+    }
+
+    val titleLabel = if (state.mode == AccountFormMode.EDIT) "Edit account" else "Account details"
+    val actionLabel = when {
+        state.isSaving -> "Saving..."
+        state.mode == AccountFormMode.EDIT -> "Update"
+        else -> "Save"
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Text(text = "Account details")
+        Text(text = titleLabel)
         OutlinedTextField(
             value = state.name,
             onValueChange = onNameChanged,
@@ -90,7 +111,7 @@ fun AddAccountScreen(
             enabled = state.canSave && !state.isSaving,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text(text = if (state.isSaving) "Saving..." else "Save")
+            Text(text = actionLabel)
         }
 
         TextButton(onClick = onClose, modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/java/com/andydel/financemanager/ui/addaccount/AddAccountUiState.kt
+++ b/app/src/main/java/com/andydel/financemanager/ui/addaccount/AddAccountUiState.kt
@@ -3,6 +3,8 @@ package com.andydel.financemanager.ui.addaccount
 import com.andydel.financemanager.domain.model.AccountType
 import com.andydel.financemanager.domain.model.Currency
 
+enum class AccountFormMode { CREATE, EDIT }
+
 data class AddAccountUiState(
     val name: String = "",
     val initialBalance: String = "",
@@ -11,7 +13,10 @@ data class AddAccountUiState(
     val selectedCurrencyId: Long? = null,
     val errorMessage: String? = null,
     val isSaving: Boolean = false,
-    val saved: Boolean = false
+    val saved: Boolean = false,
+    val mode: AccountFormMode = AccountFormMode.CREATE,
+    val editingAccountId: Long? = null,
+    val isLoading: Boolean = false
 ) {
     val canSave: Boolean
         get() = name.isNotBlank() && selectedCurrencyId != null

--- a/app/src/main/java/com/andydel/financemanager/ui/components/FinanceTopBar.kt
+++ b/app/src/main/java/com/andydel/financemanager/ui/components/FinanceTopBar.kt
@@ -1,6 +1,7 @@
 package com.andydel.financemanager.ui.components
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -19,6 +20,7 @@ import androidx.compose.runtime.setValue
 @Composable
 fun FinanceTopBar(
     title: String,
+    onNavigateHome: () -> Unit,
     onAddAccount: () -> Unit,
     onShowSummary: () -> Unit,
     onShowSettings: () -> Unit
@@ -26,6 +28,11 @@ fun FinanceTopBar(
     var expanded by remember { mutableStateOf(false) }
     TopAppBar(
         title = { Text(text = title) },
+        navigationIcon = {
+            IconButton(onClick = onNavigateHome) {
+                Icon(imageVector = Icons.Default.Home, contentDescription = "Go home")
+            }
+        },
         actions = {
             IconButton(onClick = { expanded = true }) {
                 Icon(imageVector = Icons.Default.MoreVert, contentDescription = "More")

--- a/app/src/main/java/com/andydel/financemanager/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/andydel/financemanager/ui/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.andydel.financemanager.ui.home
 
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -28,7 +29,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.andydel.financemanager.domain.model.Account
@@ -40,7 +40,8 @@ private data class TabDefinition(val type: AccountType, val title: String)
 fun HomeScreen(
     state: HomeUiState,
     onAddTransaction: (Long?) -> Unit,
-    onOpenAccount: (Long) -> Unit
+    onOpenAccount: (Long) -> Unit,
+    onEditAccount: (Long) -> Unit
 ) {
     val tabs = remember {
         listOf(
@@ -96,7 +97,8 @@ fun HomeScreen(
                     AccountList(
                         accounts = accountsForTab,
                         modifier = Modifier.fillMaxSize(),
-                        onAccountOpen = onOpenAccount
+                        onAccountOpen = onOpenAccount,
+                        onAccountEdit = onEditAccount
                     )
                 }
             }
@@ -124,7 +126,8 @@ fun HomeScreen(
 private fun AccountList(
     accounts: List<Account>,
     modifier: Modifier = Modifier,
-    onAccountOpen: (Long) -> Unit
+    onAccountOpen: (Long) -> Unit,
+    onAccountEdit: (Long) -> Unit
 ) {
     LazyColumn(
         modifier = modifier,
@@ -132,19 +135,25 @@ private fun AccountList(
         verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(12.dp)
     ) {
         items(accounts, key = Account::id) { account ->
-            AccountCard(account = account, onDoubleClick = { onAccountOpen(account.id) })
+            AccountCard(
+                account = account,
+                onOpen = { onAccountOpen(account.id) },
+                onEdit = { onAccountEdit(account.id) }
+            )
         }
     }
 }
 
 @Composable
-private fun AccountCard(account: Account, onDoubleClick: () -> Unit) {
+@OptIn(ExperimentalFoundationApi::class)
+private fun AccountCard(account: Account, onOpen: () -> Unit, onEdit: () -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .pointerInput(Unit) {
-                detectTapGestures(onDoubleTap = { onDoubleClick() })
-            },
+            .combinedClickable(
+                onClick = onOpen,
+                onLongClick = onEdit
+            ),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {

--- a/app/src/main/java/com/andydel/financemanager/ui/navigation/FinanceDestination.kt
+++ b/app/src/main/java/com/andydel/financemanager/ui/navigation/FinanceDestination.kt
@@ -2,7 +2,7 @@ package com.andydel.financemanager.ui.navigation
 
 sealed class FinanceDestination(val route: String) {
     data object Home : FinanceDestination("home")
-    data object AddAccount : FinanceDestination("addAccount")
+    data object AddAccount : FinanceDestination("addAccount?accountId={accountId}")
     data object AddTransaction : FinanceDestination("addTransaction?accountId={accountId}")
     data object AccountDetail : FinanceDestination("accountDetail/{accountId}")
     data object Summary : FinanceDestination("summary")
@@ -10,9 +10,12 @@ sealed class FinanceDestination(val route: String) {
 
     companion object {
         const val TRANSACTION_ACCOUNT_ID_KEY = "accountId"
+        const val ACCOUNT_FORM_ACCOUNT_ID_KEY = "accountId"
         const val ACCOUNT_DETAIL_ACCOUNT_ID_KEY = "accountId"
         fun addTransactionRoute(accountId: Long?): String =
             if (accountId != null) "addTransaction?accountId=$accountId" else "addTransaction?accountId=-1"
         fun accountDetailRoute(accountId: Long): String = "accountDetail/$accountId"
+        fun addAccountRoute(accountId: Long? = null): String =
+            if (accountId != null) "addAccount?accountId=$accountId" else "addAccount?accountId=-1"
     }
 }


### PR DESCRIPTION
## Summary
- add a home icon button to the top bar and wire it to pop to the dashboard
- switch account cards to single-tap open and long-press edit navigation
- reuse the account form for editing with repository support for updates

## Testing
- ./gradlew assembleDebug